### PR TITLE
harden needs validation and state updates

### DIFF
--- a/fxmanifest.lua
+++ b/fxmanifest.lua
@@ -17,7 +17,6 @@ shared_scripts {
 }
 
 client_scripts {
-    'client/ui.lua',
     'client/effects.lua',
     'client/ox.lua',
     'client/main.lua'

--- a/server/ges.lua
+++ b/server/ges.lua
@@ -17,6 +17,7 @@ end
 if GES.modules.temperature and Config.Policy.enableFromTemperature then
     RegisterNetEvent('ges:temperature:changed', function(data)
         local src = source
+        if type(data) ~= 'table' then return end
         if data.band == 'cold' then
             for k,v in pairs(Config.Policy.temperature.cold) do
                 setMult(src, k, v)
@@ -32,6 +33,7 @@ end
 if GES.modules.wetness and Config.Policy.enableFromWetness then
     RegisterNetEvent('ges:wetness:changed', function(data)
         local src = source
+        if type(data) ~= 'table' or type(data.level) ~= 'number' then return end
         if data.level >= 80 then
             for k,v in pairs(Config.Policy.wetness.soaked) do
                 setMult(src, k, v)
@@ -53,11 +55,16 @@ end
 if GES.modules.injury and Config.Policy.enableFromInjury then
     RegisterNetEvent('ges:injury:update', function(data)
         local src = source
+        if type(data) ~= 'table' then return end
         if data.bleeding then
             for k,v in pairs(Config.Policy.injury.bleeding) do setMult(src, k, v) end
+        else
+            for k,_ in pairs(Config.Policy.injury.bleeding) do setMult(src, k, nil) end
         end
         if data.fracture then
             for k,v in pairs(Config.Policy.injury.fracture) do setMult(src, k, v) end
+        else
+            for k,_ in pairs(Config.Policy.injury.fracture) do setMult(src, k, nil) end
         end
     end)
 end
@@ -65,11 +72,16 @@ end
 if GES.modules.sickness and Config.Policy.enableFromSickness then
     RegisterNetEvent('ges:sickness:update', function(data)
         local src = source
+        if type(data) ~= 'table' then return end
         if data.fever then
             for k,v in pairs(Config.Policy.sickness.fever) do setMult(src, k, v) end
+        else
+            for k,_ in pairs(Config.Policy.sickness.fever) do setMult(src, k, nil) end
         end
         if data.type == 'foodpoison' then
             for k,v in pairs(Config.Policy.sickness.foodpoison) do setMult(src, k, v) end
+        else
+            for k,_ in pairs(Config.Policy.sickness.foodpoison) do setMult(src, k, nil) end
         end
     end)
 end

--- a/server/main.lua
+++ b/server/main.lua
@@ -46,6 +46,7 @@ AddEventHandler('playerDropped', function()
     local src = source
     local data = API.SvrGetAllNeeds(src)
     if data then Persist.Save(src, data) end
+    thresholds[src] = nil
 end)
 
 CreateThread(function()

--- a/server/ox.lua
+++ b/server/ox.lua
@@ -3,6 +3,7 @@ local API = require 'shared/api'
 local Utils = require 'shared/utils'
 
 local hasOxInv = GetResourceState('ox_inventory') == 'started'
+local cooldowns = {}
 
 if not hasOxInv then
     Utils.Debug('ox_inventory not running; skipping item registration')
@@ -11,36 +12,41 @@ end
 
 for item, data in pairs(Config.Items) do
     exports.ox_inventory:registerUsableItem(item, function(src, item)
-        local cdKey = ('cd:%s:%s'):format(src, item.name)
+        local cdKey = ('%s:%s'):format(src, item.name)
         local now = os.time()
-        if GlobalState[cdKey] and GlobalState[cdKey] > now then return end
-        GlobalState[cdKey] = now + 2
+        if cooldowns[cdKey] and cooldowns[cdKey] > now then return end
+        cooldowns[cdKey] = now + 2
         TriggerClientEvent('fivem-needs:client:useItem', src, item.name, data)
     end)
 end
 
 RegisterNetEvent('fivem-needs:server:consumeItem', function(item)
     local src = source
+    if type(item) ~= 'string' then return end
     local data = Config.Items[item]
     if not data then return end
-    if exports.ox_inventory:RemoveItem(src, item, 1) then
-        if data.hunger then API.SvrAddNeed(src, 'hunger', data.hunger) end
-        if data.thirst then API.SvrAddNeed(src, 'thirst', data.thirst) end
-        if data.energy then API.SvrAddNeed(src, 'energy', data.energy) end
-        if data.stress then API.SvrAddNeed(src, 'stress', data.stress) end
-        if data.debuff then
-            for k,v in pairs(data.debuff) do
+    local cdKey = ('%s:%s'):format(src, item)
+    local now = os.time()
+    if cooldowns[cdKey] and cooldowns[cdKey] > now then return end
+    local removed = exports.ox_inventory:RemoveItem(src, item, 1)
+    if not removed or removed < 1 then return end
+    cooldowns[cdKey] = now + 2
+    if data.hunger then API.SvrAddNeed(src, 'hunger', data.hunger) end
+    if data.thirst then API.SvrAddNeed(src, 'thirst', data.thirst) end
+    if data.energy then API.SvrAddNeed(src, 'energy', data.energy) end
+    if data.stress then API.SvrAddNeed(src, 'stress', data.stress) end
+    if data.debuff then
+        for k,v in pairs(data.debuff) do
+            if k ~= 'duration' then
+                GlobalState[('m:%s:%s'):format(src, k)] = v
+            end
+        end
+        SetTimeout((data.debuff.duration or 60) * 1000, function()
+            for k,_ in pairs(data.debuff) do
                 if k ~= 'duration' then
-                    GlobalState[('m:%s:%s'):format(src, k)] = v
+                    GlobalState[('m:%s:%s'):format(src, k)] = nil
                 end
             end
-            SetTimeout((data.debuff.duration or 60) * 1000, function()
-                for k,_ in pairs(data.debuff) do
-                    if k ~= 'duration' then
-                        GlobalState[('m:%s:%s'):format(src, k)] = nil
-                    end
-                end
-            end)
-        end
+        end)
     end
 end)

--- a/shared/api.lua
+++ b/shared/api.lua
@@ -60,11 +60,13 @@ else -- SERVER SIDE
 
     function API.SvrSetNeed(src, name, val)
         local p = API.EnsurePlayer(src)
-        p[name] = Utils.Clamp(val, Config.MinValue, Config.MaxValue)
+        local clamped = Utils.Clamp(val, Config.MinValue, Config.MaxValue)
+        if p[name] == clamped then return end
+        p[name] = clamped
         local player = Player(src)
         if player then
-            player.state:set('need:'..name, p[name], true)
-            GlobalState['p:'..src..':'..name] = p[name]
+            player.state:set('need:'..name, clamped, true)
+            GlobalState['p:'..src..':'..name] = clamped
         end
     end
 
@@ -91,13 +93,19 @@ else -- SERVER SIDE
         players[source] = nil
     end)
 
+    local function validate(name, val)
+        return type(name) == 'string' and type(val) == 'number' and API.Defs[name]
+    end
+
     RegisterNetEvent('fivem-needs:set', function(name, val)
         local src = source
+        if not validate(name, val) then return end
         API.SvrSetNeed(src, name, val)
     end)
 
     RegisterNetEvent('fivem-needs:add', function(name, val)
         local src = source
+        if not validate(name, val) then return end
         API.SvrAddNeed(src, name, val)
     end)
 end


### PR DESCRIPTION
## Summary
- enforce need name/value validation on server events
- throttle item consumption and remove global cooldown state
- cleanup player threshold data on disconnect
- reset GES multipliers and add missing table checks
- remove unused client/ui script reference

## Testing
- `luacheck .` *(fails: command not found)*
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689ae5a281a48332b1182caff22bc728